### PR TITLE
Added embed example to general command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "kt2"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "dotenv",
  "poise",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kt2"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/deployments/dev/docker-compose.yml
+++ b/deployments/dev/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   db:
     image: postgres
-    container_name: postgres
+    container_name: postgres-dev
     restart: always
     environment:
       POSTGRES_USER: dev-user

--- a/src/commands/general.rs
+++ b/src/commands/general.rs
@@ -1,4 +1,5 @@
 use crate::Context;
+use poise::serenity_prelude::{CreateEmbed, Colour};
 
 /// Show help menu
 #[poise::command(prefix_command, track_edits, slash_command)]
@@ -22,8 +23,15 @@ pub async fn help(
 
 #[poise::command(prefix_command, slash_command)]
 pub async fn schedule(ctx: Context<'_>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let response = "Game nights are every Tuesday and Thursday 7:30PM to 11:30PM EST!";
-    ctx.say(response).await?;
+    let embed = CreateEmbed::default()
+        .title("Game Night Schedule")
+        .description("Game nights are every Tuesday and Thursday 7:30PM to 11:30PM EST!")
+        .colour(Colour::from_rgb(255, 0, 0));
+    
+    let reply = poise::CreateReply::default().embed(embed);
+
+    ctx.send(reply).await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
This commit adds an example of how to use embeds in the general command. This is a simple example that shows how to create a basic embed with a title, description, and colour.